### PR TITLE
feat(API): expose download_metadata function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,7 @@ homepage = "https://github.com/textileio/entanglement"
 license = "MIT OR Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/textileio/entanglement"
-keywords = [
-    "recall",
-    "alpha-entanglement",
-    "data-availability",
-]
+keywords = ["recall", "alpha-entanglement", "data-availability"]
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/entangler/src/entangler.rs
+++ b/entangler/src/entangler.rs
@@ -321,7 +321,7 @@ impl<T: Storage> Entangler<T> {
         }
     }
 
-    pub(crate) async fn download_metadata(&self, metadata_hash: &str) -> Result<Metadata, Error> {
+    pub async fn download_metadata(&self, metadata_hash: &str) -> Result<Metadata, Error> {
         let stream = self.storage.download_bytes(metadata_hash).await?;
         Ok(serde_json::from_slice(&read_stream(stream).await?)?)
     }


### PR DESCRIPTION
The entangler::download_metadata is now public so that other modules can call it and don't need to download and parse metadata themselves.