### PR TITLE
chore: rename packages to be more consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,7 +3709,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "recall_entanglement_cli"
+name = "recall_entangler"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "cid",
+ "futures",
+ "iroh",
+ "recall_entangler_storage",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+]
+
+[[package]]
+name = "recall_entangler_cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -3718,8 +3735,8 @@ dependencies = [
  "clap",
  "clap-stdin",
  "futures",
- "recall_entanglement_storage",
  "recall_entangler",
+ "recall_entangler_storage",
  "serde",
  "serde_json",
  "stderrlog",
@@ -3728,7 +3745,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "recall_entanglement_storage"
+name = "recall_entangler_storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -3745,23 +3762,6 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "uuid",
-]
-
-[[package]]
-name = "recall_entangler"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "cid",
- "futures",
- "iroh",
- "recall_entanglement_storage",
- "serde",
- "serde_json",
- "thiserror 2.0.11",
- "tokio",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "recall_entanglement_cli"
+name = "recall_entangler_cli"
 description = "A command line interface (CLI) for the Aplha Entanglement."
 authors.workspace = true
 edition.workspace = true
@@ -28,4 +28,4 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 recall_entangler = { path = "../entangler", version = "0.1.0" }
-recall_entanglement_storage = { path = "../storage", version = "0.1.0" }
+recall_entangler_storage = { path = "../storage", version = "0.1.0" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,8 +12,8 @@ use futures::StreamExt;
 use std::str::FromStr;
 use stderrlog::Timestamp;
 
-use recall_entanglement_storage::iroh::IrohStorage;
 use recall_entangler::{ByteStream, Config, Entangler};
+use recall_entangler_storage::iroh::IrohStorage;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/entangler/Cargo.toml
+++ b/entangler/Cargo.toml
@@ -22,10 +22,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
-recall_entanglement_storage = { version = "0.1.0", path = "../storage", features = [] }
+recall_entangler_storage = { version = "0.1.0", path = "../storage", features = [] }
 
 [dev-dependencies]
-recall_entanglement_storage = { path = "../storage", features = ["mock"] }
+recall_entangler_storage = { path = "../storage", features = ["mock"] }
 
 [lib]
 doctest = false

--- a/entangler/src/entangler.rs
+++ b/entangler/src/entangler.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use bytes::{Bytes, BytesMut};
 use futures::TryStreamExt;
 use futures::{Stream, StreamExt};
-use recall_entanglement_storage::{self, ChunkIdMapper, Error as StorageError, Storage};
+use recall_entangler_storage::{self, ChunkIdMapper, Error as StorageError, Storage};
 use std::collections::HashMap;
 use std::pin::Pin;
 
@@ -66,7 +66,7 @@ pub struct EntanglementResult {
     /// The hash of the metadata blob.
     pub metadata_hash: String,
     /// Results from all storage uploads (original blob in case of `upload`, parity blobs, and metadata blob).
-    pub upload_results: Vec<recall_entanglement_storage::UploadResult>,
+    pub upload_results: Vec<recall_entangler_storage::UploadResult>,
 }
 
 /// The `Entangler` struct is responsible for managing the entanglement process of data chunks.
@@ -173,7 +173,7 @@ impl<T: Storage> Entangler<T> {
         &self,
         bytes: Bytes,
         hash: String,
-    ) -> Result<(String, Vec<recall_entanglement_storage::UploadResult>)> {
+    ) -> Result<(String, Vec<recall_entangler_storage::UploadResult>)> {
         let num_bytes = bytes.len();
 
         let chunks = bytes_to_chunks(bytes, CHUNK_SIZE);
@@ -447,7 +447,7 @@ impl<T: Storage> Entangler<T> {
 }
 
 async fn read_stream(
-    mut stream: recall_entanglement_storage::ByteStream,
+    mut stream: recall_entangler_storage::ByteStream,
 ) -> Result<Bytes, anyhow::Error> {
     let mut bytes = BytesMut::with_capacity(stream.size_hint().0);
     while let Some(chunk) = stream.next().await {
@@ -484,7 +484,7 @@ fn add_padding(chunk: &Bytes, chunk_size: usize) -> Bytes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use recall_entanglement_storage::mock::{DummyStorage, SpyStorage};
+    use recall_entangler_storage::mock::{DummyStorage, SpyStorage};
 
     #[test]
     fn test_entangler_new_valid_parameters() {

--- a/entangler/src/repairer.rs
+++ b/entangler/src/repairer.rs
@@ -5,7 +5,7 @@ use crate::grid::{Dir, Pos, Positioner};
 use crate::lattice::{Graph, NodeId, NodeType};
 use crate::parity::StrandType;
 use anyhow::Result;
-use recall_entanglement_storage::{ChunkIdMapper, Error as StorageError, Storage};
+use recall_entangler_storage::{ChunkIdMapper, Error as StorageError, Storage};
 
 use crate::Metadata;
 use bytes::Bytes;

--- a/entangler/src/stream.rs
+++ b/entangler/src/stream.rs
@@ -3,7 +3,7 @@
 
 use crate::entangler::{ByteStream, Entangler, Error};
 use bytes::Bytes;
-use recall_entanglement_storage::{self, Error as StorageError, Storage};
+use recall_entangler_storage::{self, Error as StorageError, Storage};
 
 use futures::{future::Future, ready, task::Poll, Stream, StreamExt, TryStreamExt};
 use std::pin::Pin;
@@ -19,7 +19,7 @@ type ByteStreamFuture = Pin<Box<dyn Future<Output = Result<ByteStream, Error>> +
 ///
 /// This stream ensures data integrity by automatically repairing corrupted chunks during streaming.
 pub struct RepairingStream<T: Storage + 'static> {
-    inner: recall_entanglement_storage::ByteStream,
+    inner: recall_entangler_storage::ByteStream,
     entangler: Entangler<T>,
     hash: String,
     metadata_hash: String,
@@ -43,7 +43,7 @@ impl<T: Storage + 'static> RepairingStream<T> {
         entangler: Entangler<T>,
         hash: String,
         metadata_hash: String,
-        inner: recall_entanglement_storage::ByteStream,
+        inner: recall_entangler_storage::ByteStream,
     ) -> Self {
         Self {
             entangler,
@@ -115,7 +115,7 @@ impl<T: Storage + 'static> RepairingStream<T> {
                         match ff_future.as_mut().poll(cx) {
                             Poll::Ready(Ok(fast_forwarded_stream)) => {
                                 self.inner = Box::pin(fast_forwarded_stream.map_err(|e| {
-                                    StorageError::Other(recall_entanglement_storage::wrap_error(
+                                    StorageError::Other(recall_entangler_storage::wrap_error(
                                         e.into(),
                                     ))
                                 }));
@@ -125,7 +125,7 @@ impl<T: Storage + 'static> RepairingStream<T> {
                         }
                     } else {
                         self.inner = Box::pin(new_stream.map_err(|e| {
-                            StorageError::Other(recall_entanglement_storage::wrap_error(e.into()))
+                            StorageError::Other(recall_entangler_storage::wrap_error(e.into()))
                         }));
                     }
                     Ok(())

--- a/entangler/tests/entangler_test.rs
+++ b/entangler/tests/entangler_test.rs
@@ -4,8 +4,8 @@
 use anyhow::Result;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{Stream, StreamExt};
-use recall_entanglement_storage::{self, mock::FakeStorage, ChunkIdMapper, Storage};
 use recall_entangler::{self, parity::StrandType, ChunkRange, Config, Entangler, Metadata};
+use recall_entangler_storage::{self, mock::FakeStorage, ChunkIdMapper, Storage};
 use std::collections::HashSet;
 use std::str::FromStr;
 
@@ -38,8 +38,8 @@ fn xor_chunks(chunk1: &[u8], chunk2: &[u8]) -> Bytes {
 
 fn new_entangler_from_node<S: iroh::blobs::store::Store>(
     node: &iroh::node::Node<S>,
-) -> Result<Entangler<recall_entanglement_storage::iroh::IrohStorage>, recall_entangler::Error> {
-    let st = recall_entanglement_storage::iroh::IrohStorage::from_client(node.client().clone());
+) -> Result<Entangler<recall_entangler_storage::iroh::IrohStorage>, recall_entangler::Error> {
+    let st = recall_entangler_storage::iroh::IrohStorage::from_client(node.client().clone());
     Entangler::new(st, Config::new(3, HEIGHT as u8, HEIGHT as u8))
 }
 
@@ -994,7 +994,7 @@ async fn if_download_fails_it_should_upload_to_storage_after_repair() -> Result<
         let res = storage.download_bytes(&upload_result.hash).await;
         assert!(matches!(
             res,
-            Err(recall_entanglement_storage::Error::BlobNotFound(_))
+            Err(recall_entangler_storage::Error::BlobNotFound(_))
         ));
 
         match t.method {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "recall_entanglement_storage"
+name = "recall_entangler_storage"
 description = "Distributed storage for uploading and downloading data."
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
The packages here used a mixture of `entangler` and `entanglement` in the names.  This changes to be consistent with `entangler` as per discussion here: https://github.com/recallnet/rust-recall/issues/17