### PR TITLE
fix: remove trailing commas so workflow can run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,22 @@ jobs:
             })
 
       - name: Publish
-        run: >
-          cargo publish
-          --verbose
-          --workspace
-          --locked
-          --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish \
+          --verbose \
+          --locked \
+          --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
+          --package recall_entangler_storage
+          cargo publish \
+          --verbose \
+          --locked \
+          --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
+          --package recall_entangler
+          cargo publish \
+          --verbose \
+          --locked \
+          --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
+          --package recall_entangler_cli
 
       - name: Release 🚀
         uses: ncipollo/release-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ async-trait = "0.1.80"
 bytes = "1.6.0"
 cid = { version = "0.10.1", default-features = false, features = [
     "serde-codec",
-    "std",
+    "std"
 ] }
 clap = { version = "4.1.14", features = [
     "color",
     "derive",
     "env",
     "string",
-    "unicode",
+    "unicode"
 ] }
 clap-stdin = { version = "0.6.0", features = ["tokio"] }
 iroh = "0.28.1"


### PR DESCRIPTION
This is two fixes to the release workflow.  The first attempt failed because the action we are using to read the package version out of Cargo.toml does not allow trailing commas in arrays.  Additionally the `--workspace` flag for `cargo publish` is only available for the nightly version of cargo.  I think we want to use stable, so I broke the publishing into one command for each package.

In regard to the trailing comma issue. This differs from our normal linting rules.  Maybe we want to look for an alternative action?