### PR TITLE
feat: use stream for uploading data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,6 +3742,7 @@ dependencies = [
  "stderrlog",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 stderrlog = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { version = "0.7.10", features = ["io"] }
 
 recall_entangler = { path = "../entangler", version = "0.1.0" }
 recall_entangler_storage = { path = "../storage", version = "0.1.0" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,9 +9,11 @@ use std::net::SocketAddr;
 
 use bytes::Bytes;
 use clap::{Args, Parser, Subcommand};
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use std::str::FromStr;
 use stderrlog::Timestamp;
+use tokio::{fs::File, io};
+use tokio_util::io::ReaderStream;
 
 use recall_entangler::{ByteStream, Config, Entangler};
 use recall_entangler_storage::iroh::IrohStorage;
@@ -124,11 +126,6 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Upload(args) => {
-            use futures::TryStreamExt;
-            use tokio::fs::File;
-            use tokio::io::{self};
-            use tokio_util::io::ReaderStream;
-
             let file = File::open(&args.file)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to open file {}: {}", args.file, e))?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -129,7 +129,6 @@ async fn main() -> anyhow::Result<()> {
             use tokio::io::{self};
             use tokio_util::io::ReaderStream;
 
-            // Open the file
             let file = File::open(&args.file)
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to open file {}: {}", args.file, e))?;

--- a/entangler/src/entangler.rs
+++ b/entangler/src/entangler.rs
@@ -149,7 +149,7 @@ impl<T: Storage> Entangler<T> {
     /// and all upload results from the underlying storage.
     pub async fn upload<S, E>(&self, stream: S) -> Result<EntanglementResult>
     where
-        S: Stream<Item = Result<Bytes, E>> + Send + Unpin,
+        S: Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
         E: std::error::Error + Send + Sync + 'static,
     {
         let mut upload_results = Vec::new();

--- a/entangler/src/entangler.rs
+++ b/entangler/src/entangler.rs
@@ -180,11 +180,6 @@ impl<T: Storage> Entangler<T> {
     /// The original data is also uploaded to the storage backend.
     /// Returns the hash of the metadata and the upload results for parity blobs and metadata.
     async fn entangle(&self, bytes: Bytes, hash: String) -> Result<(String, Vec<UploadResult>)> {
-    async fn entangle(
-        &self,
-        bytes: Bytes,
-        hash: String,
-    ) -> Result<(String, Vec<UploadResult>)> {
         let num_bytes = bytes.len();
 
         let chunks = bytes_to_chunks(bytes, CHUNK_SIZE);

--- a/entangler/src/stream.rs
+++ b/entangler/src/stream.rs
@@ -3,9 +3,10 @@
 
 use crate::entangler::{ByteStream, Entangler, Error};
 use bytes::Bytes;
-use recall_entangler_storage::{self, Error as StorageError, Storage};
-
 use futures::{future::Future, ready, task::Poll, Stream, StreamExt, TryStreamExt};
+use recall_entangler_storage::{
+    self, ByteStream as StorageByteStream, Error as StorageError, Storage,
+};
 use std::pin::Pin;
 use std::task::Context;
 
@@ -19,7 +20,7 @@ type ByteStreamFuture = Pin<Box<dyn Future<Output = Result<ByteStream, Error>> +
 ///
 /// This stream ensures data integrity by automatically repairing corrupted chunks during streaming.
 pub struct RepairingStream<T: Storage + 'static> {
-    inner: recall_entangler_storage::ByteStream,
+    inner: StorageByteStream,
     entangler: Entangler<T>,
     hash: String,
     metadata_hash: String,
@@ -43,7 +44,7 @@ impl<T: Storage + 'static> RepairingStream<T> {
         entangler: Entangler<T>,
         hash: String,
         metadata_hash: String,
-        inner: recall_entangler_storage::ByteStream,
+        inner: StorageByteStream,
     ) -> Self {
         Self {
             entangler,

--- a/entangler/tests/entangler_test.rs
+++ b/entangler/tests/entangler_test.rs
@@ -77,12 +77,12 @@ async fn load_parity_data_to_node<S>(
 use recall_entangler::read_stream;
 
 // Helper function to convert bytes to a stream for tests
-fn bytes_to_stream<T>(bytes: T) -> storage::ByteStream
+fn bytes_to_stream<T>(bytes: T) -> ByteStream
 where
     T: Into<Bytes> + Send + 'static,
 {
     Box::pin(futures::stream::once(async move {
-        Ok::<Bytes, storage::Error>(bytes.into())
+        Ok::<Bytes, StorageError>(bytes.into())
     }))
 }
 

--- a/storage/src/iroh.rs
+++ b/storage/src/iroh.rs
@@ -165,7 +165,6 @@ impl Storage for IrohStorage {
     {
         use futures::TryStreamExt;
 
-        // Convert the error type of the stream to match what iroh expects
         let iroh_stream = stream
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
             .map_ok(|bytes| bytes);

--- a/storage/src/iroh.rs
+++ b/storage/src/iroh.rs
@@ -19,17 +19,6 @@ use crate::storage::{
     self, ByteStream, ChunkId, ChunkIdMapper, ChunkStream, Error as StorageError, Storage,
 };
 
-// Helper function to convert bytes to a stream for tests
-#[cfg(test)]
-fn bytes_to_stream<T>(bytes: T) -> impl Stream<Item = Result<Bytes, StorageError>> + Send + Unpin
-where
-    T: Into<Bytes> + Send,
-{
-    Box::pin(futures::stream::once(async move {
-        Ok::<Bytes, StorageError>(bytes.into())
-    }))
-}
-
 const CHUNK_SIZE: u64 = 1024;
 
 /// `ClientProvider` is a trait for types that can provide an Iroh client.
@@ -310,6 +299,18 @@ mod tests {
     use bytes::Bytes;
     use futures::StreamExt;
     use tokio;
+
+    #[cfg(test)]
+    fn bytes_to_stream<T>(
+        bytes: T,
+    ) -> impl Stream<Item = Result<Bytes, StorageError>> + Send + Unpin
+    where
+        T: Into<Bytes> + Send,
+    {
+        Box::pin(futures::stream::once(async move {
+            Ok::<Bytes, StorageError>(bytes.into())
+        }))
+    }
 
     async fn collect_chunks(storage: &IrohStorage, hash: &str) -> Result<Vec<Bytes>> {
         let stream = storage.iter_chunks(hash).await?;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -37,13 +37,18 @@
 //! use crate::storage::Storage;
 //! use crate::iroh::IrohStorage;
 //! use bytes::Bytes;
-//! use futures::StreamExt;
+//! use futures::{StreamExt, Stream};
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
 //!     let storage = IrohStorage::new_in_memory().await?;
 //!     let data = b"Hello, world!".to_vec();
-//!     let upload_result = storage.upload_bytes(data.clone()).await?;
+//!     let data_clone = data.clone();
+//!     // Create a stream from the data
+//!     let data_stream = Box::pin(futures::stream::once(async move {
+//!         Ok::<Bytes, std::io::Error>(Bytes::from(data_clone))
+//!     }));
+//!     let upload_result = storage.upload_bytes(data_stream).await?;
 //!
 //!     // Download the data as a single blob
 //!     let mut stream = storage.download_bytes(&upload_result.hash).await?;

--- a/storage/src/mock.rs
+++ b/storage/src/mock.rs
@@ -126,7 +126,6 @@ impl Storage for FakeStorage {
         S: Stream<Item = Result<Bytes, E>> + Send + Unpin,
         E: std::error::Error + Send + Sync + 'static,
     {
-        // Collect all the bytes from the stream
         use futures::TryStreamExt;
         let mut all_bytes = Vec::new();
         let mut stream = stream.map_err(|e| StorageError::Other(e.to_string()));

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -88,13 +88,16 @@ pub trait Storage: Send + Sync + Clone {
     ///
     /// # Arguments
     ///
-    /// * `bytes` - The bytes to upload.
+    /// * `stream` - A stream of bytes to upload.
     ///
     /// # Returns
     ///
     /// A `Result` containing the upload result with hash of the uploaded data and additional info,
     /// or an error if the upload fails.
-    async fn upload_bytes(&self, bytes: impl Into<Bytes> + Send) -> Result<UploadResult, Error>;
+    async fn upload_bytes<S, E>(&self, stream: S) -> Result<UploadResult, Error>
+    where
+        S: Stream<Item = Result<Bytes, E>> + Send + Unpin,
+        E: std::error::Error + Send + Sync + 'static;
 
     /// Downloads the bytes identified by the given hash as a stream of bytes.
     ///

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -96,7 +96,7 @@ pub trait Storage: Send + Sync + Clone {
     /// or an error if the upload fails.
     async fn upload_bytes<S, E>(&self, stream: S) -> Result<UploadResult, Error>
     where
-        S: Stream<Item = Result<Bytes, E>> + Send + Unpin,
+        S: Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
         E: std::error::Error + Send + Sync + 'static;
 
     /// Downloads the bytes identified by the given hash as a stream of bytes.


### PR DESCRIPTION
Resolves https://github.com/recallnet/entanglement/issues/19

Refactor upload methods to handle streams instead of byte arrays, reducing memory usage and improving performance during uploads. This change allows for more efficient file handling and supports streaming data directly to the storage.

