### PR TITLE
feat: make metadata deterministic

### DIFF
--- a/entangler/src/entangler.rs
+++ b/entangler/src/entangler.rs
@@ -189,13 +189,13 @@ impl<T: Storage> Entangler<T> {
 
         let exec = executer::Executer::new(self.config.alpha);
 
-        let mut parity_hashes = HashMap::new();
+        let mut parity_hashes = Vec::new();
         let mut upload_results = Vec::new();
 
         for parity_grid in exec.iter_parities(orig_grid) {
             let data = parity_grid.grid.assemble_data();
             let upload_result = self.storage.upload_bytes(bytes_to_stream(data)).await?;
-            parity_hashes.insert(parity_grid.strand_type, upload_result.hash.clone());
+            parity_hashes.push(upload_result.hash.clone());
             upload_results.push(upload_result);
         }
 
@@ -614,7 +614,7 @@ mod tests {
         let metadata = Metadata {
             orig_hash: hash.clone(),
             num_bytes: 18,
-            parity_hashes: HashMap::new(),
+            parity_hashes: Vec::new(),
             chunk_size: 6,
             s: 3,
             p: 3,

--- a/entangler/src/metadata.rs
+++ b/entangler/src/metadata.rs
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-
-use crate::parity::StrandType;
 
 /// Metadata struct that holds information about the original blob and the parity blobs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     pub orig_hash: String,
-    pub parity_hashes: HashMap<StrandType, String>,
+    pub parity_hashes: Vec<String>,
     pub num_bytes: u64,
     pub chunk_size: u64,
     pub s: u8,

--- a/entangler/src/parity.rs
+++ b/entangler/src/parity.rs
@@ -16,11 +16,35 @@ pub enum StrandType {
 }
 
 impl StrandType {
+    /// Turns the strand type into an integer that can be used for navigation in the grid.
     pub fn to_i64(self) -> i64 {
         match self {
             StrandType::Left => -1,
             StrandType::Horizontal => 0,
             StrandType::Right => 1,
+        }
+    }
+
+    /// Turns the strand type into an integer that can be used indexing into a vector.
+    /// This is useful for storing the strand type in a vector.
+    /// The order is: Left, Horizontal, Right.
+    pub fn to_index(self) -> usize {
+        match self {
+            StrandType::Left => 0,
+            StrandType::Horizontal => 1,
+            StrandType::Right => 2,
+        }
+    }
+
+    /// Converts an index into a strand type.
+    /// This is useful for converting a vector index into a strand type.
+    /// The order is: Left, Horizontal, Right.
+    pub fn try_from_index(index: usize) -> Option<Self> {
+        match index {
+            0 => Some(StrandType::Left),
+            1 => Some(StrandType::Horizontal),
+            2 => Some(StrandType::Right),
+            _ => None,
         }
     }
 

--- a/entangler/src/repairer.rs
+++ b/entangler/src/repairer.rs
@@ -325,13 +325,16 @@ impl<T: Storage> Healer<T> {
     fn get_blob_hash_for_type(&self, grid_type: NodeType) -> &str {
         match grid_type {
             NodeType::Data => &self.metadata.orig_hash,
-            NodeType::ParityLeft => self.metadata.parity_hashes.get(&StrandType::Left).unwrap(),
-            NodeType::ParityHorizontal => self
-                .metadata
-                .parity_hashes
-                .get(&StrandType::Horizontal)
-                .unwrap(),
-            NodeType::ParityRight => self.metadata.parity_hashes.get(&StrandType::Right).unwrap(),
+            NodeType::ParityLeft | NodeType::ParityHorizontal | NodeType::ParityRight => {
+                let strand_type = match grid_type {
+                    NodeType::ParityLeft => StrandType::Left,
+                    NodeType::ParityHorizontal => StrandType::Horizontal,
+                    NodeType::ParityRight => StrandType::Right,
+                    _ => unreachable!(),
+                };
+
+                &self.metadata.parity_hashes[strand_type.to_index()]
+            }
         }
     }
 }

--- a/entangler/tests/entangler_test.rs
+++ b/entangler/tests/entangler_test.rs
@@ -1250,14 +1250,12 @@ async fn test_deterministic_metadata_hash() -> Result<()> {
         let metadata = load_metadata(&result.metadata_hash, &storage).await?;
         let first_metadata = load_metadata(&first_metadata_hash, &storage).await?;
 
-        // Verify lengths match
         assert_eq!(
             metadata.parity_hashes.len(),
             first_metadata.parity_hashes.len(),
             "Number of parity hashes should be consistent"
         );
 
-        // Verify each hash and type matches
         for i in 0..metadata.parity_hashes.len() {
             assert_eq!(
                 metadata.parity_hashes[i], first_metadata.parity_hashes[i],


### PR DESCRIPTION
Resolves https://github.com/recallnet/entanglement/issues/42

Make metadata deterministic by replacing `strand_type -> parity_hash` map with just a vector of `parity_hash`s.
We don't need to store strand types in metadata as their order is constant and can be deduced from their index.